### PR TITLE
don't copy image data

### DIFF
--- a/SDWebImage/Core/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/Core/SDWebImageDownloaderOperation.m
@@ -388,7 +388,7 @@ didReceiveResponse:(NSURLResponse *)response
     BOOL supportProgressive = (self.options & SDWebImageDownloaderProgressiveLoad) && !self.decryptor;
     if (supportProgressive) {
         // Get the image data
-        NSData *imageData = [self.imageData copy];
+        NSData *imageData = self.imageData;
         
         // keep maximum one progressive decode process during download
         if (self.coderQueue.operationCount == 0) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none
(technically i found https://github.com/SDWebImage/SDWebImage/pull/3167/files but it is a different line in the same file)
* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)


### Pull Request Description

I have the following crash log which is similar to a similar issue with a different PR (linked above).  I just copied that PRs solution.  This is currently the top crash in the application I work in.

Fatal Exception: NSInvalidArgumentException
*** NSAllocateMemoryPages(67164) failed
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x129708 __exceptionPreprocess
1  libobjc.A.dylib                0x287a8 objc_exception_throw
2  Foundation                     0x13c234 NSZoneMalloc
3  Foundation                     0xecf4 -[_NSPlaceholderData initWithBytes:length:copy:deallocator:]
4  SDWebImage                     0x25dbc -[SDWebImageDownloaderOperation URLSession:dataTask:didReceiveData:] + 391 (SDWebImageDownloaderOperation.m:391)
5  SDWebImage                     0x22740 -[SDWebImageDownloader URLSession:dataTask:didReceiveData:] + 447 (SDWebImageDownloader.m:447)

